### PR TITLE
nlas/allowedip: fix bad prefix length for retrieved IPv*Network objects

### DIFF
--- a/wgnlpy/nlas/allowedip.py
+++ b/wgnlpy/nlas/allowedip.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 from socket import AF_INET, AF_INET6
-from ipaddress import IPv4Network, IPv6Network, ip_network
+from ipaddress import IPv4Address, IPv6Address, IPv4Network, IPv6Network, ip_network
 from pyroute2.netlink import nla, NLA_F_NESTED
 
 class allowedip(nla):
@@ -22,10 +22,14 @@ class allowedip(nla):
         )
 
         try:
+            addr = {
+                AF_INET: IPv4Address,
+                AF_INET6: IPv6Address,
+            }[family](ipaddr)
             return {
                 AF_INET: IPv4Network,
                 AF_INET6: IPv6Network,
-            }[family](ipaddr, cidr_mask)
+            }[family]("{}/{}".format(addr, cidr_mask))
         except:
             raise NotImplementedError
 


### PR DESCRIPTION
The returned `allowedips` objects always have a maximum prefix length (`/32` or `/128`). This seems to be caused since `IPv*Network` does not support specifying the prefix length with tuples:

```python
>>> from ipaddress import IPv4Address, IPv4Network
>>> IPv4Network(int(IPv4Address('10.0.0.0')), 20)
IPv4Network('10.0.0.0/32')
```

The PR uses a intermediate step to create a `IPv*Network` object with the correct prefix length:

```python
>>> IPv4Network("{}/{}".format(IPv4Address('10.0.0.0'), 20))
IPv4Network('10.0.0.0/20')
```
May be there is a more efficient way to solve this issue.
