### PR TITLE
handle situation where wireguard netlink returns invalid data

### DIFF
--- a/wgnlpy/wireguardinfo.py
+++ b/wgnlpy/wireguardinfo.py
@@ -35,7 +35,7 @@ class WireGuardInfo(object):
         for message in messages:
             wgp = lambda p: WireGuardPeer(p, spill_preshared_keys)
             for peer in map(wgp, message.get_attr('WGDEVICE_A_PEERS') or []):
-                assert peer.public_key not in self.peers
+                if peer.public_key in self.peers: continue
                 self.peers[peer.public_key] = peer
 
     def __repr__(self):

--- a/wgnlpy/wireguardpeer.py
+++ b/wgnlpy/wireguardpeer.py
@@ -27,7 +27,10 @@ class WireGuardPeer(object):
         self.endpoint = peer.get_attr('WGPEER_A_ENDPOINT')
         self.persistent_keepalive_interval = peer.get_attr('WGPEER_A_PERSISTENT_KEEPALIVE_INTERVAL')
         self.last_handshake_time = peer.get_attr('WGPEER_A_LAST_HANDSHAKE_TIME')
-        if not self.last_handshake_time > 0:
+        try:
+            if not self.last_handshake_time > 0:
+                self.last_handshake_time = None
+        except TypeError:
             self.last_handshake_time = None
         self.rx_bytes = peer.get_attr('WGPEER_A_RX_BYTES')
         self.tx_bytes = peer.get_attr('WGPEER_A_TX_BYTES')


### PR DESCRIPTION
We occasionally encounter that wg interface returns invalid data.
Either returns NULL in last handshake or returns a peer twice.

This short patch handles these situations.